### PR TITLE
Allow context_idx to equal zero in get_pairs

### DIFF
--- a/src/ml/data_loader.py
+++ b/src/ml/data_loader.py
@@ -178,7 +178,7 @@ class Sequences:
         for center_idx, node in enumerate(sequence):
             for i in range(-window, window + 1):
                 context_idx = center_idx + i
-                if context_idx > 0 and context_idx < len(sequence) and node != sequence[
+                if context_idx >= 0 and context_idx < len(sequence) and node != sequence[
                     context_idx] and np.random.rand() < self.discard_probs[sequence[context_idx]]:
                     pairs.append((node, sequence[context_idx]))
 

--- a/src/ml/data_loader_with_meta.py
+++ b/src/ml/data_loader_with_meta.py
@@ -266,7 +266,7 @@ class Sequences:
         for center_idx, center in enumerate(sequence):
             for i in range(-window, window + 1):
                 context_idx = center_idx + i
-                if context_idx > 0 and context_idx < len(sequence) and center != sequence[
+                if context_idx >= 0 and context_idx < len(sequence) and center != sequence[
                     context_idx] and np.random.rand() < self.discard_probs[sequence[context_idx]]:
                     context = sequence[context_idx]
                     center_meta = self.get_meta(center)


### PR DESCRIPTION
Hi Eugene!

Thank you for everything you've done for the community. I consult your curated papers regularly.

While working through your skipgrams example, I noticed off-by-one issues in `get_pairs` in these classes:
* `src/ml/data_loader.Sequences`
*  `src/ml/data_loader_with_meta.Sequences`

Namely, `if context_idx > 0` means that the `context_idx` can never be zero. Here's a reproducible example (with discard probabilities removed for clarity):

```
import numpy as np

class Sequences:
    def __init__(self):
        self.sequences = [[0, 1, 2]]

    def get_pairs(self, idx, window=5):
        pairs = []
        sequence = self.sequences[idx]

        for center_idx, node in enumerate(sequence):
            for i in range(-window, window + 1):
                context_idx = center_idx + i
                if context_idx > 0 and context_idx < len(sequence) and node != sequence[
                    context_idx]:
                    pairs.append((node, sequence[context_idx]))

        return pairs
```

In the below, the pairs `(1, 0)` and `(2, 0)` are missing:
```
sequences = Sequences()
sequences.get_pairs(idx=0)

> [
>   (0, 1), 
>   (0, 2), 
>   (1, 2), 
>   (2, 1),
> ]
```

Changing the condition to `if context_idx >= 0` resolves the issue:

```
import numpy as np

class Sequences:
    def __init__(self):
        self.sequences = [[0, 1, 2]]

    def get_pairs(self, idx, window=5):
        pairs = []
        sequence = self.sequences[idx]

        for center_idx, node in enumerate(sequence):
            for i in range(-window, window + 1):
                context_idx = center_idx + i
                if context_idx >= 0 and context_idx < len(sequence) and node != sequence[
                    context_idx]:
                    pairs.append((node, sequence[context_idx]))

        return pairs
```
```
sequences = Sequences()
sequences.get_pairs(idx=0)

> [
>   (0, 1), 
>   (0, 2), 
>   (1, 0),  # now included in pairs
>   (1, 2), 
>   (2, 0),  # now included in pairs
>   (2, 1),
> ]
```

Let me know if you have any questions!

Justin
